### PR TITLE
replace setTimeout with Vue.nextTick & add vue dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
+    "vue": "^1.0.25",
     "vue-popup": "^0.1.8"
   }
 }

--- a/src/msgbox.vue
+++ b/src/msgbox.vue
@@ -263,11 +263,11 @@
 
       visible(val) {
         if (val && this.$type === 'prompt') {
-          setTimeout(() => {
+          Vue.nextTick(() => {
             if (this.$els.input) {
               this.$els.input.focus();
             }
-          }, 500);
+          });
         }
       }
     },


### PR DESCRIPTION
``` javascript
MessageBox.prompt = function(message, title, options) {
  if (typeof title === 'object') {
    options = title;
    title = '';
  }
  return MessageBox(merge({
    title: title,
    message: message,
    showCancelButton: true,
    showInput: true,
    $type: 'prompt'
  }, options));
};
```

好像关于`prompt`的配置，已经设置了`showInput: true`，感觉不用再去判断`this.$els.input`了好像~

sorry，刚发现还是应该去判断下的 :)
